### PR TITLE
Allows user to specify frameworks to be excluded

### DIFF
--- a/ccp/__init__.py
+++ b/ccp/__init__.py
@@ -26,6 +26,7 @@
 
 from __future__ import print_function
 
+import argparse
 import os
 import os.path
 import subprocess
@@ -34,9 +35,16 @@ import sys
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-
 def main():
     sanity_check()
+
+    parser = argparse.ArgumentParser(description='Exclude dependencies')
+    parser.add_argument('-x','--exclude', nargs='+', help='Exclude dependencies from being copied', required=False)
+    args = parser.parse_args()
+    if args.exclude is not None:
+        excluded_frameworks = args.exclude
+    else:
+        excluded_frameworks = []
 
     built_products_dir = os.environ["BUILT_PRODUCTS_DIR"]
     frameworks_folder_path = os.environ["FRAMEWORKS_FOLDER_PATH"]
@@ -45,7 +53,7 @@ def main():
     dest = os.path.join(built_products_dir, frameworks_folder_path)
     frameworks_dir = os.path.abspath(os.path.join(srcroot, "Carthage", "Build", "iOS"))
 
-    frameworks = [f for f in os.listdir(frameworks_dir) if f.endswith(".framework")]
+    frameworks = [f for f in os.listdir(frameworks_dir) if f.endswith(".framework") and f not in excluded_frameworks]
 
     # Skip speed-up trick for Release builds.
     if os.environ["CONFIGURATION"] != "Release":
@@ -56,7 +64,6 @@ def main():
     # Do we have anything to do?
     if not frameworks:
         print("Not copying any framework. Perform a clean build to copy them again.")
-
         return
     else:
         print("Copying:\n    " + "\n    ".join(frameworks))
@@ -90,7 +97,6 @@ def sanity_check():
 
 def already_there(dest, framework_name):
     return os.path.isdir(os.path.join(dest, framework_name))
-
 
 if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,16 @@ from setuptools import setup
 
 HERE = path.abspath(path.dirname(__file__))
 
-with open_f(path.join(HERE, "DESCRIPTION.rst"), encoding="utf-8") as f:
-    LONG_DESCRIPTION = f.read()
+try:
+    with open_f(path.join(HERE, "DESCRIPTION.rst"), encoding="utf-8") as f:
+        LONG_DESCRIPTION = f.read()
+except IOError:
+    LONG_DESCRIPTION = ""
 
 setup(
     name="carthage-copy-frameworks",
     version="1.0.0",
-    description="Keyring integration and local execution wrappers for Ansible",
+    description="carthage-copy-frameworks is an helper script that automatically copies every framework below Carthage/Build/iOS",
     long_description=LONG_DESCRIPTION,
     url="https://github.com/lvillani/carthage-copy-frameworks",
     author="Lorenzo Villani",


### PR DESCRIPTION
Some frameworks are test frameworks or stub frameworks, which shouldn't be included with the main app.

I've added an exclude parameter that allows the user to exclude certain frameworks.
e.g.:
`carthage-copy-frameworks --exclude OHHTTPStubs.framework Nimble.framework`

I also edited the setup.py as it was giving errors from PIP. (couldn't find DESCRIPTION.rst)
